### PR TITLE
Feature/remove faker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,3 @@ gem 'slim', '3.0.7'
 gem 'sassc', '1.10.0'
 gem 'compass', '1.0.3' # Using compass temporarily so we can have sass 3.3, remove this when Middleman without compass dependency is released
 gem 'coffee-script', '2.4.1'
-
-# Generate fake data
-gem 'faker', '1.6.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,8 +38,6 @@ GEM
     erubis (2.7.0)
     eventmachine (1.2.0.1)
     execjs (2.7.0)
-    faker (1.6.3)
-      i18n (~> 0.5)
     ffi (1.9.10)
     git-version-bump (0.15.1)
     haml (4.0.7)
@@ -154,7 +152,6 @@ PLATFORMS
 DEPENDENCIES
   coffee-script (= 2.4.1)
   compass (= 1.0.3)
-  faker (= 1.6.3)
   middleman (= 3.4.1)
   middleman-autoprefixer (= 2.7.0)
   middleman-livereload (= 3.4.6)

--- a/helpers/content_helpers.rb
+++ b/helpers/content_helpers.rb
@@ -12,24 +12,3 @@ end
 def current_year
   Time.now.year
 end
-
-# Faker helpers
-def random_name
-  Faker::Name.name
-end
-
-def random_address
-  "#{Faker::Address.street_address},<br/>#{Faker::Address.city}, #{Faker::Address.state}<br/>#{Faker::Address.postcode}"
-end
-
-def random_company_name
-  Faker::Company.name
-end
-
-def random_phone_number
-  Faker::PhoneNumber.phone_number
-end
-
-def random_email_address
-  Faker::Internet.email
-end


### PR DESCRIPTION
This PR removes Faker gem from middleman-startae. I don't think is a common need to a lot of projects built in Middleman.

Please review @startae/frontend-team 
