### PR TITLE
Add netlify button to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![forthebadge](http://forthebadge.com/images/badges/fuck-it-ship-it.svg)](http://www.startae.com)
 [![forthebadge](http://forthebadge.com/images/badges/built-with-love.svg)](http://www.startae.com)
 
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/startae/middleman-startae/tree/master)
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/startae/middleman-startae)
 
 **Features:**

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 [![forthebadge](http://forthebadge.com/images/badges/fuck-it-ship-it.svg)](http://www.startae.com)
 [![forthebadge](http://forthebadge.com/images/badges/built-with-love.svg)](http://www.startae.com)
 
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/startae/middleman-startae)
+
 **Features:**
-* Ready to run on [Heroku](http://www.heroku.com)
+* Ready to run on [Heroku](http://www.heroku.com) or [Netlify](http://www.netlify.com)
 * [Livereload](http://livereload.com): automatically refresh your browser whenever you edit files in your site.
 * [Slim](http://slim-lang.com): A lightweight templating engine.
 * [Bower](http://bower.io): A package manager for the web.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,7 @@
+{
+  "name": "Middleman Startae",
+  "description": "A starter template ready to run on Heroku",
+  "repository": "https://github.com/startae/middleman-startae",
+  "logo": "http://torspark.com/img/middleman-logo.png",
+  "keywords": ["middleman", "ruby", "static"]
+}


### PR DESCRIPTION
[PR Title must summarize changes and not be named `feature/something`]

##### Done in this PR

I found this template while looking for already styled middleman boilerplates for a [site](http://pizza.netlify.com) I am creating.

Deploying a middleman site makes sense to Heroku because it works, but it is pricey. I added a deploy to Netlify button in addition to the Heroku mention for another option for users that use this template. 

##### Known issues

- heroku's minimum plan $7
- Netlify is free for all projects and increases to $9 for more features. There is an [opensource](https://www.netlify.com/open-source) plan available as well.

##### To-do

- nothing else is needed to make this work

##### Demo
- test the button here

[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/bdougie/middleman-startae)

Please review it, @startae/frontend-team.
