### PR TITLE
Remove Modernizr import

### DIFF
--- a/source/shared/_head.slim
+++ b/source/shared/_head.slim
@@ -9,12 +9,6 @@ meta http-equiv='X-UA-Compatible' content='IE=edge'
 meta content='on' http-equiv='cleartype'
 meta content='True' name='HandheldFriendly'
 meta content='320' name='MobileOptimized'
-/ -------------------------------------
-/ Modernizr - Development version
-/ This is the Development version. Remember to use
-/ the build tool below to pick only the tests you need.
-/ -------------------------------------
-= javascript_include_tag '//cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.js'
 /[if lt IE 9]
   = javascript_include_tag '//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js'
   = javascript_include_tag '//cdnjs.cloudflare.com/ajax/libs/respond.js/1.4.2/respond.min.js'


### PR DESCRIPTION
##### Done in this PR

In favor of simplicity, this PR removes Modernizr import. Since we don't use on every project, I think it's better to import on a specific project if needed.

Please review it, @startae/frontend-team.
