### PR TITLE
Add defer tag to javascript imports

### DIFF
--- a/source/shared/_body_bottom.slim
+++ b/source/shared/_body_bottom.slim
@@ -1,6 +1,6 @@
 = partial '/shared/analytics'
-= javascript_include_tag 'requirements'
-= javascript_include_tag 'application'
+= javascript_include_tag 'requirements', defer: true
+= javascript_include_tag 'application', defer: true
 
 /[if lt IE 9]
   = javascript_include_tag '//cdnjs.cloudflare.com/ajax/libs/nwmatcher/1.3.6/nwmatcher.min.js'


### PR DESCRIPTION
##### Done in this PR

This PRs add the `defer` to the javascripts that we load at the end of the site. It helps on the performance of the site.

More about the subject:
- http://stackoverflow.com/a/25420553/925560
- http://www.growingwiththeweb.com/2014/02/async-vs-defer-attributes.html

Please review it, @startae/frontend-team.
