### PR TITLE
Remove faker from our readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@
 * [Coffeescript](http://coffeescript.org)
 * Language configuration
 * Gzip
-* Faker (Fake content generator with several helpers predefined)
 * Preconfigured partials
 * Metatags helper
 


### PR DESCRIPTION
##### Done in this PR
- Remove the `faker` gem from our README, since we removed it

Please review it, @startae/frontend-team.
