### PR TITLE
Disable webpack cleaning on Linux development

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,10 @@
 var webpack = require('webpack')
 var ExtractTextPlugin = require('extract-text-webpack-plugin')
 var Clean = require('clean-webpack-plugin')
+var os = require('os');
+
+// Cleaning is disabled on linux development because it causes middleman server to stop serving assets
+var pathsToClean = os.platform() === 'linux' && process.env.NODE_ENV === 'development' ? [] : ['.tmp']
 
 module.exports = {
   entry: {
@@ -78,7 +82,7 @@ module.exports = {
         NODE_ENV: JSON.stringify(process.env.NODE_ENV),
       },
     }),
-    new Clean(['.tmp']),
+    new Clean(pathsToClean),
     new ExtractTextPlugin('assets/stylesheets/[name].bundle.css'),
   ],
 }


### PR DESCRIPTION
##### Done in this PR
When running `middleman s` on a Linux machine the clean-webpack-plugin cleaning causes middleman to stop serving the assets. This was solved by making plugin param an empty array on Linux. Also this isn't a problem for production builds since middleman doesn't serve those, so i also check if the env is development.

##### Known issues

- Linux users will need to clean .tmp manually.

##### To-do

##### Demo

Please review it, @startae/frontend-team.
